### PR TITLE
Fix setsockopts

### DIFF
--- a/tunnel.c
+++ b/tunnel.c
@@ -140,25 +140,25 @@ static int
 tunnel_in_setsockopts (int fd)
 {
 #ifdef SO_RCVLOWAT
-      int i, n;
+  int i, n;
 
-      i = 1;
-      if (setsockopt (fd,
-		      SOL_SOCKET,
-		      SO_RCVLOWAT,
-		      (void *)&i,
-		      sizeof i) == -1)
-	{
-	  log_debug ("tunnel_in_setsockopts: non-fatal SO_RCVLOWAT error: %s",
-		     strerror (errno));
-	}
-      n = sizeof i;
-      getsockopt (fd,
+  i = 1;
+  if (setsockopt (fd,
 		  SOL_SOCKET,
 		  SO_RCVLOWAT,
 		  (void *)&i,
-		  &n);
-      log_debug ("tunnel_out_setsockopts: SO_RCVLOWAT: %d", i);
+		  sizeof i) == -1)
+    {
+      log_debug ("tunnel_in_setsockopts: non-fatal SO_RCVLOWAT error: %s",
+		  strerror (errno));
+    }
+  n = sizeof i;
+  getsockopt (fd,
+	      SOL_SOCKET,
+	      SO_RCVLOWAT,
+	      (void *)&i,
+	      &n);
+  log_debug ("tunnel_out_setsockopts: SO_RCVLOWAT: %d", i);
 #endif /* SO_RCVLOWAT */
 
   return 0;
@@ -171,24 +171,24 @@ tunnel_out_setsockopts (int fd)
   {
     int i, n;
  
-	i = 1;
-	if (setsockopt (fd,
-			SOL_SOCKET,
-			SO_SNDLOWAT,
-			(void *)&i,
-			sizeof i) == -1)
-	  {
-	    log_debug ("tunnel_out_setsockopts: "
-		       "non-fatal SO_SNDLOWAT error: %s",
-		       strerror (errno));
-	  }
-	n = sizeof i;
-	getsockopt (fd,
+    i = 1;
+    if (setsockopt (fd,
 		    SOL_SOCKET,
 		    SO_SNDLOWAT,
 		    (void *)&i,
-		    &n);
-	log_debug ("tunnel_out_setsockopts: non-fatal SO_SNDLOWAT: %d", i);
+		    sizeof i) == -1)
+      {
+	log_debug ("tunnel_out_setsockopts: "
+		    "non-fatal SO_SNDLOWAT error: %s",
+		    strerror (errno));
+      }
+    n = sizeof i;
+    getsockopt (fd,
+		SOL_SOCKET,
+		SO_SNDLOWAT,
+		(void *)&i,
+		&n);
+    log_debug ("tunnel_out_setsockopts: non-fatal SO_SNDLOWAT: %d", i);
   }
 #endif /* SO_SNDLOWAT */
 


### PR DESCRIPTION
There were two misbehaving setsockopts. Both SO_RCVLOWAT and SO_SNDLOWAT are socket-level options and not TCP-level options.

The latter (SO_SNDLOWAT == 19) has a catastrophic effect on the socket, because it is interpreted as TCP_REPAIR (http://lxr.linux.no/#linux+v3.12.5/include/uapi/linux/tcp.h#L108) and basically doesn't let any more data through. This only happens if htc is run as root; otherwise the kernel returns -EPERM and nothing bad happens.
