### PR TITLE
Address some FIXMEs (buffer overflows mostly)

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -520,7 +520,7 @@ main (int argc, char **argv)
 	  int timeout;
 	  time_t t;
 	  int n;
-      
+
 	  pollfd[0].fd = fd;
 	  pollfd[0].events = POLLIN;
 	  pollfd[1].fd = tunnel_pollin_fd (tunnel);
@@ -564,11 +564,11 @@ main (int argc, char **argv)
           close (fd);
 	}
       tunnel_close (tunnel);
-      log_notice ("disconnected from FIXME:hostname:port");
+      log_notice ("disconnected from %s:%s", arg.forward_host, arg.forward_port);
     }
 
   log_debug ("destroying tunnel");
   tunnel_destroy (tunnel);
- 
+
   log_exit (0);
 }

--- a/tunnel.c
+++ b/tunnel.c
@@ -1168,7 +1168,7 @@ tunnel_accept (Tunnel *tunnel)
 
 	      tunnel_out_setsockopts (tunnel->out_fd);
 
-	      sprintf (str,
+	      snprintf (str, sizeof(str),
 "HTTP/1.1 200 OK\r\n"
 /* "Date: %s\r\n" */
 /* "Server: %s\r\n" */


### PR DESCRIPTION
Hi there,

in this PR I replace the usage of `sprintf()` with `snprintf()`, and then there is a second commit that addresses a FIXME in the log message.